### PR TITLE
Upgrade from .NET 8 to .NET 10

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,12 +11,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up .NET
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Restore dependencies
         run: dotnet restore

--- a/SimpleMailer/SimpleMailer.csproj
+++ b/SimpleMailer/SimpleMailer.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyTitle>SimpleMailer</AssemblyTitle>


### PR DESCRIPTION
.NET 8 EOL is November 2026; .NET 10 is the current LTS.
Also bumps actions/checkout and actions/setup-dotnet to v4.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
